### PR TITLE
Implement std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-rgb = "0.7"
+rgb = "0.8"
 
 [dev-dependencies]
 bencher = "0.1"
 
 [dev-dependencies.image]
-version = "0.14"
+version = "0.22"
 default-features = false
 features = ["jpeg", "png_codec"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate rgb;
 
 use std::cmp;
 use std::fmt;
+use std::error;
 use std::u8;
 
 pub use rgb::RGB8 as Color;
@@ -59,6 +60,8 @@ impl fmt::Display for Error {
         write!(f, "{}", msg)
     }
 }
+
+impl error::Error for Error {}
 
 /// Returns a representative color palette of an image.
 ///


### PR DESCRIPTION
This allows crates like failure and snafu to integrate this crate's errors.