### PR TITLE
Fix off by one error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ fn cut(
         ColorChannel::Blue =>  (vbox.b_min as i32, vbox.b_max as i32),
     };
 
-    for i in vbox_min..vbox_max {
+    for i in vbox_min..vbox_max + 1 {
         if partial_sum[i as usize] <= total / 2 {
             continue;
         }


### PR DESCRIPTION
Since the `for .. in` range is exclusive, the loop was not checking the last element in `partial_sum` which was causing a `VBoxCutFailed` error on some images.